### PR TITLE
Cache Mapbox token for reuse

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,8 +1,11 @@
 // config.js
 
+let CACHED_TOKEN = null;
+
 export async function getMapboxToken() {
+  if (CACHED_TOKEN) return CACHED_TOKEN;
   if (typeof window !== 'undefined' && window.__MAPBOX_TOKEN__) {
-    return window.__MAPBOX_TOKEN__;
+    return (CACHED_TOKEN = window.__MAPBOX_TOKEN__);
   }
   try {
     const res = await fetch('/api/env', { cache: 'no-store' });
@@ -10,6 +13,7 @@ export async function getMapboxToken() {
       const { MAPBOX_TOKEN } = await res.json();
       const token = (MAPBOX_TOKEN || '').trim();
       if (token) {
+        CACHED_TOKEN = token;
         if (typeof window !== 'undefined') window.__MAPBOX_TOKEN__ = token;
         return token;
       }


### PR DESCRIPTION
## Summary
- cache Mapbox token after first fetch to avoid redundant requests
- sync token between in-memory cache and `window.__MAPBOX_TOKEN__`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fca20a1d88321a09aaf54d53fe362