### PR TITLE
Add environment check banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
     <div id="map-error" class="hidden" role="alert"></div>
   </main>
 
+  <script src="/env-check.js" defer></script>
   <script type="module" src="/map.js?v=10"></script>
   <script type="module" src="/app.js?v=10"></script>
 </body>

--- a/public/env-check.js
+++ b/public/env-check.js
@@ -1,0 +1,36 @@
+(function(){
+  const params = new URLSearchParams(location.search);
+  const debugEnv = params.get('debug') === 'env';
+
+  function showBanner(msg){
+    const banner = document.createElement('div');
+    banner.id = 'env-banner';
+    banner.textContent = msg;
+    banner.style.cssText = 'position:fixed;top:0;left:0;right:0;padding:4px 8px;background:#b91c1c;color:#fff;font-size:12px;text-align:center;z-index:3000';
+    document.body.appendChild(banner);
+  }
+
+  async function init(){
+    let data = {};
+    try{
+      const res = await fetch('/api/env', {cache:'no-store'});
+      if(res.ok) data = await res.json();
+    }catch(_){ }
+
+    const token = (data.MAPBOX_TOKEN || '').trim();
+    if (token) {
+      window.__MAPBOX_TOKEN__ = token;
+    }
+
+    if(!token || debugEnv){
+      const msg = debugEnv ? `env: ${JSON.stringify(data)}` : 'MAPBOX_TOKEN missing';
+      showBanner(msg);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add env-check script to warn when MAPBOX_TOKEN missing or debug flag set
- ensure index.html loads env-check before map setup

## Testing
- `npm test`
- `npm run build`
- `node --input-type=module <verify script>` (missing token)
- `node --input-type=module <verify script with debug>`

------
https://chatgpt.com/codex/tasks/task_e_689fcbbf9d7c8321895cd3a5a8e171c1