### PR TITLE
fix: stabilize build id

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,7 +24,11 @@ export async function getMapboxToken() {
 
 export function getBuildId() {
   if (typeof window !== 'undefined' && window.__BUILD_ID__) return window.__BUILD_ID__;
-  const id = String(Date.now());
+  let id = '1';
+  try {
+    const url = new URL(import.meta.url);
+    id = url.searchParams.get('v') || id;
+  } catch {}
   if (typeof window !== 'undefined') window.__BUILD_ID__ = id;
   return id;
 }


### PR DESCRIPTION
## Summary
- derive build ID from script URL instead of Date.now

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fcd49fe988321b15ebdde13ea3c42