### PR TITLE
chore: bump to v11 and fix Mapbox token loading

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-// app.js — v10
+// app.js — v11
 import { getBuildId } from './config.js';
 
 // Normaliza etiquetas de dificultad a buckets
@@ -107,7 +107,7 @@ if (typeof window !== 'undefined') {
   // ---- Service Worker ----
   if ('serviceWorker' in navigator) {
       window.addEventListener('load', async () => {
-        const reg = await navigator.serviceWorker.register(`/sw-v10.js?v=${getBuildId()}`);
+        const reg = await navigator.serviceWorker.register(`/sw-v11.js?v=${getBuildId()}`);
 
         // If there’s a waiting SW, tell it to activate; do NOT await a reply.
         if (reg.waiting) {

--- a/build.js
+++ b/build.js
@@ -51,14 +51,13 @@ try {
   console.warn("Skip bundle step:", e?.message);
 }
 
-// === Genera dist/config.js con el token público ===
+// === Generate dist/config.js for the bundle ===
 try {
   const distDir = path.join(ROOT, "dist");
   ensureDir(distDir);
 
-  // lee el token desde variables de entorno de Vercel (Preview/Production)
   const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN || "";
-  const buildId = "v10"; // súbelo cuando cambies assets
+  const buildId = "v11";
 
   const cfg = `// generated at build time
 export const MAPBOX_TOKEN = ${JSON.stringify(token)};
@@ -79,5 +78,6 @@ copyDir(path.join(ROOT, "public"), OUT);
 
 copy(path.join(ROOT, "styles.css"), path.join(OUT, "styles.css"));
 copy(path.join(ROOT, "index.html"), path.join(OUT, "index.html"));
+copy(path.join(ROOT, "sw-v11.js"), path.join(OUT, "sw-v11.js"));
 
 console.log("✅ Build Completed in /vercel/output");

--- a/config.js
+++ b/config.js
@@ -1,15 +1,5 @@
 // config.js
+export const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN || '';
+export const BUILD_ID = 'v11';
+export function getBuildId(){ return BUILD_ID; }
 
-let CACHED_TOKEN = null;
-let TOKEN_PROMISE = null;
-
-export async function getMapboxToken() {
-  if (typeof window !== 'undefined' && window.__MAPBOX_TOKEN__) return window.__MAPBOX_TOKEN__;
-  if (CACHED_TOKEN) return CACHED_TOKEN;
-}
-
-let BUILD_ID = null;
-
-export function getBuildId() {
-  
-}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>It's Gountain</title>
 
   <!-- PWA / Manifest -->
-  <link rel="manifest" href="/manifest.json?v=10">
+  <link rel="manifest" href="/manifest.json?v=11">
   <meta name="theme-color" content="#00a0c6">
   <meta name="background-color" content="#ffffff">
   <meta name="mobile-web-app-capable" content="yes">
@@ -17,24 +17,24 @@
   <script src="https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.js" defer></script>
 
   <!-- Favicons / Touch Icons (con cache-busting) -->
-  <link rel="icon" href="/assets/GountainTime-192.png?v=10" type="image/png" sizes="192x192">
-  <link rel="icon" href="/assets/GountainTime-512.png?v=10" type="image/png" sizes="512x512">
-  <link rel="apple-touch-icon" href="/assets/GountainTime-192.png?v=10" sizes="192x192">
-  <link rel="apple-touch-icon" href="/assets/GountainTime-512.png?v=10" sizes="512x512">
+  <link rel="icon" href="/assets/GountainTime-192.png?v=11" type="image/png" sizes="192x192">
+  <link rel="icon" href="/assets/GountainTime-512.png?v=11" type="image/png" sizes="512x512">
+  <link rel="apple-touch-icon" href="/assets/GountainTime-192.png?v=11" sizes="192x192">
+  <link rel="apple-touch-icon" href="/assets/GountainTime-512.png?v=11" sizes="512x512">
 
   <!-- Social share -->
   <meta property="og:title" content="It's Gountain">
   <meta property="og:description" content="Explora y descubre más de 40 picos impresionantes en esta webapp interactiva.">
-  <meta property="og:image" content="https://its-gountain-time.vercel.app/assets/GountainTime-512.png?v=10">
+  <meta property="og:image" content="https://its-gountain-time.vercel.app/assets/GountainTime-512.png?v=11">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://its-gountain-time.vercel.app">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="It's Gountain">
   <meta name="twitter:description" content="Explora y descubre más de 40 picos impresionantes en esta webapp interactiva.">
-  <meta name="twitter:image" content="https://its-gountain-time.vercel.app/assets/GountainTime-512.png?v=10">
+  <meta name="twitter:image" content="https://its-gountain-time.vercel.app/assets/GountainTime-512.png?v=11">
 
   <!-- CSS con cache-busting -->
-  <link rel="stylesheet" href="/styles.css?v=10">
+  <link rel="stylesheet" href="/styles.css?v=11">
 </head>
 
 <body>
@@ -111,18 +111,18 @@
     </aside>
 
     <div id="map"></div>
-    <div id="map-health" class="map-health">Fetching token...</div>
+    <div id="map-health" class="map-health">Loading map...</div>
     <div id="map-error" class="hidden" role="alert"></div>
   </main>
 
   <!-- Tu JS (usar el bundle que genera build.js) -->
-  <script type="module" src="/dist/app.bundle.js?v=10"></script>
+  <script type="module" src="/dist/app.bundle.js?v=11"></script>
 
   <!-- (Opcional) Registrar SW estable; cuando hagas limpieza usa sw-kill.js temporalmente -->
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw-v10.js?v=10').catch(console.error);
+        navigator.serviceWorker.register('/sw-v11.js?v=11').catch(console.error);
       });
     }
   </script>

--- a/map.js
+++ b/map.js
@@ -1,4 +1,4 @@
-import { getMapboxToken, getBuildId } from './config.js';
+import { MAPBOX_TOKEN, getBuildId } from './config.js';
 
 /* global mapboxgl */
 let map;
@@ -13,8 +13,7 @@ let __MAPBOX_MOUNTED__ = false;
 async function initMapOnce(){
   if (__MAPBOX_MOUNTED__) return;
   __MAPBOX_MOUNTED__ = true;
-  setHealth('Fetching token...');
-  const token = await getMapboxToken().catch(() => '');
+  const token = MAPBOX_TOKEN;
   if (!token) {
     setHealth('No token');
     alert('Map cannot load (token missing).');

--- a/public/env-check.js
+++ b/public/env-check.js
@@ -1,4 +1,4 @@
-import { getMapboxToken } from '/config.js';
+import { MAPBOX_TOKEN } from './dist/config.js';
 
 const params = new URLSearchParams(location.search);
 const debugEnv = params.get('debug') === 'env';
@@ -12,7 +12,7 @@ function showBanner(msg){
 }
 
 async function init(){
-  const token = await getMapboxToken();
+  const token = MAPBOX_TOKEN;
   if (token && !debugEnv) return;
   let data = {};
   if (debugEnv) {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Gountain Time",
   "short_name": "Gountain",
   "description": "Mapa interactivo de picos y travesías con filtros, reseñas y recomendaciones de material.",
-  "start_url": "/?v=10",
+  "start_url": "/?v=11",
   "scope": "/",
   "display": "standalone",
   "background_color": "#ffffff",
@@ -11,13 +11,13 @@
 
   "icons": [
     {
-      "src": "/assets/GountainTime-192.png?v=10",
+      "src": "/assets/GountainTime-192.png?v=11",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/assets/GountainTime-512.png?v=10",
+      "src": "/assets/GountainTime-512.png?v=11",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
@@ -28,14 +28,14 @@
     {
       "name": "Europa",
       "short_name": "Europa",
-      "url": "/?continent=Europa&v=10",
-      "icons": [{ "src": "/assets/GountainTime-192.png?v=10", "sizes": "192x192" }]
+      "url": "/?continent=Europa&v=11",
+      "icons": [{ "src": "/assets/GountainTime-192.png?v=11", "sizes": "192x192" }]
     },
     {
       "name": "Asia",
       "short_name": "Asia",
-      "url": "/?continent=Asia&v=10",
-      "icons": [{ "src": "/assets/GountainTime-192.png?v=10", "sizes": "192x192" }]
+      "url": "/?continent=Asia&v=11",
+      "icons": [{ "src": "/assets/GountainTime-192.png?v=11", "sizes": "192x192" }]
     }
   ],
 

--- a/sw-v11.js
+++ b/sw-v11.js
@@ -1,5 +1,5 @@
-// sw-v10.js
-const CACHE_NAME = 'gountain-cache-v10';
+// sw-v11.js
+const CACHE_NAME = 'gountain-cache-v11';
 
 const OFFLINE_URLS = [
   '/', 
@@ -10,68 +10,57 @@ const OFFLINE_URLS = [
   '/assets/GountainTime-512.png'
 ];
 
-// --- Install: precache offline essentials ---
+// Install
 self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS))
-  );
+  event.waitUntil(caches.open(CACHE_NAME).then((c) => c.addAll(OFFLINE_URLS)));
   self.skipWaiting();
 });
 
-// --- Activate: purge old caches y entradas problemáticas ---
+// Activate
 self.addEventListener('activate', (event) => {
   event.waitUntil((async () => {
-    // elimina caches antiguos
     const keys = await caches.keys();
     await Promise.all(keys.map((k) => k !== CACHE_NAME && caches.delete(k)));
 
-    // elimina posibles manifest.json cacheados por error
+    // remove any cached manifest
     const c = await caches.open(CACHE_NAME);
     const reqs = await c.keys();
-    await Promise.all(
-      reqs
-        .filter((r) => new URL(r.url).pathname === '/manifest.json')
-        .map((r) => c.delete(r))
-    );
+    await Promise.all(reqs
+      .filter((r) => new URL(r.url).pathname === '/manifest.json')
+      .map((r) => c.delete(r)));
   })());
   self.clients.claim();
 });
 
-// --- Helpers ---
+// Bypass helper
 const isBypassed = (url) => {
-  // rutas que NO debe tocar el SW
-  if (url.origin !== self.location.origin) return true;                      // externos (Mapbox, etc.)
-  if (url.pathname === '/manifest.json') return true;                        // manifest
-  if (url.pathname.startsWith('/_vercel')) return true;                      // vercel internals
-  if (url.pathname.includes('vercel-insights')) return true;                 // vercel insights
+  if (url.origin !== self.location.origin) return true;          // externals (Mapbox/CDNs)
+  if (url.pathname === '/manifest.json') return true;            // manifest
+  if (url.pathname.startsWith('/_vercel')) return true;          // vercel internals
+  if (url.pathname.includes('vercel-insights')) return true;     // vercel insights
   return false;
 };
 
-// --- Fetch: cache-first salvo bypass ---
+// Fetch
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  // Bypass duro: deja que el navegador vaya a red y NO caches
+  // Hard bypass: do not cache, always go to network
   if (isBypassed(url)) {
     event.respondWith(fetch(event.request, { cache: 'no-store' }).catch(() => {
-      // si falla la red y es navegación, intenta devolver index para no “romper” la app
-      if (event.request.mode === 'navigate') {
-        return caches.match('/index.html');
-      }
-      // si no, deja que falle
+      if (event.request.mode === 'navigate') return caches.match('/index.html');
       return Promise.reject();
     }));
     return;
   }
 
-  // Cache-first con fill de fondo
+  // Cache-first with background fill
   event.respondWith((async () => {
     const cached = await caches.match(event.request);
     if (cached) return cached;
 
     try {
       const res = await fetch(event.request);
-      // cachea sólo exitosos (no 4xx/5xx)
       if (res && res.ok) {
         const clone = res.clone();
         const cache = await caches.open(CACHE_NAME);

--- a/sw-v11.js
+++ b/sw-v11.js
@@ -36,6 +36,7 @@ self.addEventListener('activate', (event) => {
 const isBypassed = (url) => {
   if (url.origin !== self.location.origin) return true;          // externals (Mapbox/CDNs)
   if (url.pathname === '/manifest.json') return true;            // manifest
+  if (url.pathname.startsWith('/assets/')) return true;          // static assets
   if (url.pathname.startsWith('/_vercel')) return true;          // vercel internals
   if (url.pathname.includes('vercel-insights')) return true;     // vercel insights
   return false;

--- a/update-version.js
+++ b/update-version.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 
-// Lee versión de config.js
-const { VERSION } = require('./config.js');
+// Version used for cache-busting
+const VERSION = 'v11';
 
 // Incluye el service worker con su nombre versionado
 const filesToUpdate = ['app.js', 'index.html', 'manifest.json', 'styles.css', `sw-${VERSION}.js`];


### PR DESCRIPTION
## Summary
- bump cache-busting version to v11 across HTML, manifest, build scripts, and service worker
- generate dist/config.js with build-time Mapbox token and expose helpers
- rename and tighten service worker, use build token in map init

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f2776958832182d9445e61543e15