### PR TITLE
Add Mapbox debug page

### DIFF
--- a/public/debug.html
+++ b/public/debug.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Debug Map</title>
+  <link href="https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.css" rel="stylesheet" />
+  <style>
+    html, body, #map { height:100%; margin:0; }
+  </style>
+</head>
+<body>
+  <div id="map">Loading...</div>
+  <script src="https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.js"></script>
+  <script type="module">
+    import { MAPBOX_TOKEN } from '/dist/config.js';
+    const el = document.getElementById('map');
+    if (!MAPBOX_TOKEN) {
+      el.textContent = 'No token';
+    } else if (typeof mapboxgl === 'undefined') {
+      el.textContent = 'Mapbox GL JS failed to load';
+    } else {
+      mapboxgl.accessToken = MAPBOX_TOKEN;
+      new mapboxgl.Map({
+        container: 'map',
+        style: 'mapbox://styles/mapbox/streets-v12',
+        center: [0, 0],
+        zoom: 2
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add debug page that loads Mapbox using `/dist/config.js`

## Testing
- `node --test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4f88746988321bcda0a9e84984b42