### PR TITLE
refactor: unify service worker and enforce v12 cache busting

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // app.js — v12
 
-// Normaliza etiquetas de dificultad a buckets
+// ---------- Difficulty bucketing ----------
 export function normalizeDiff(diff) {
   if (!diff) return 'Trek';
   if (diff.startsWith('AD')) return 'AD';
@@ -10,7 +10,7 @@ export function normalizeDiff(diff) {
   return diff.includes('Trek') ? 'Trek' : diff;
 }
 
-// Paleta para botas
+// ---------- Boot palette ----------
 export const BOOT_COLORS = {
   "Cualquiera": "#22c55e",
   "Depende": "#f59e0b",
@@ -23,17 +23,6 @@ export const BOOT_COLORS = {
   "Botas triple capa (8000 m+)": "#d97706",
   "Otras ligeras (para trekking no técnico)": "#14b8a6"
 };
-
-function renderBootLegend(){
-  const ul = document.getElementById('legend-botas');
-  if (!ul) return;
-  ul.innerHTML = '';
-  Object.entries(BOOT_COLORS).forEach(([name, color]) => {
-    const li = document.createElement('li');
-    li.innerHTML = `<span style="display:inline-block;width:10px;height:10px;border-radius:999px;background:${color};margin-right:8px;border:1px solid #334155;"></span>${name}`;
-    ul.appendChild(li);
-  });
-}
 
 export function markerColor(d, bootColors = BOOT_COLORS) {
   const pr = [
@@ -48,8 +37,11 @@ export function markerColor(d, bootColors = BOOT_COLORS) {
     'Depende',
     'Otras ligeras (para trekking no técnico)'
   ];
-  for (const p of pr)
-    if (Array.isArray(d.botas) && d.botas.includes(p)) return bootColors[p] || '#22c55e';
+  for (const p of pr) {
+    if (Array.isArray(d.botas) && d.botas.includes(p)) {
+      return bootColors[p] || '#22c55e';
+    }
+  }
   return '#22c55e';
 }
 
@@ -80,14 +72,13 @@ export function monthsToSeasons(meses) {
 }
 
 export function withinFilters(d, F) {
-  const cont = F.continente.size === 0 || F.continente.has(d.continente);
-  const dif = F.dificultad.size === 0 || F.dificultad.has(normalizeDiff(d.dificultad));
-  const tipo = F.tipo.size === 0 || F.tipo.has(d.tipo);
-  const botas =
-    F.botas.size === 0 || (Array.isArray(d.botas) && d.botas.some(b => F.botas.has(b)));
-  const season = F.season.size === 0 || (Array.isArray(d.seasons) && d.seasons.some(s => F.season.has(s)));
-  const altMin = F.altitude.min == null || d.altitud_m >= F.altitude.min;
-  const altMax = F.altitude.max == null || d.altitud_m <= F.altitude.max;
+  const cont = F.continente?.size === 0 || F.continente?.has?.(d.continente);
+  const dif = F.dificultad?.size === 0 || F.dificultad?.has?.(normalizeDiff(d.dificultad));
+  const tipo = F.tipo?.size === 0 || F.tipo?.has?.(d.tipo);
+  const botas = F.botas?.size === 0 || (Array.isArray(d.botas) && d.botas.some(b => F.botas.has(b)));
+  const season = F.season?.size === 0 || (Array.isArray(d.seasons) && d.seasons.some(s => F.season.has(s)));
+  const altMin = F.altitude?.min == null || d.altitud_m >= F.altitude.min;
+  const altMax = F.altitude?.max == null || d.altitud_m <= F.altitude.max;
   return cont && dif && tipo && botas && season && altMin && altMax;
 }
 
@@ -105,24 +96,38 @@ export function computeBounds(list) {
   return { west, south, east, north };
 }
 
+// ---------- Small UI hooks (no SW here) ----------
+function renderBootLegend() {
+  const ul = document.getElementById('legend-botas');
+  if (!ul) return;
+  ul.innerHTML = '';
+  Object.entries(BOOT_COLORS).forEach(([name, color]) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<span class="pill" style="background:${color}33;border-color:${color};color:#fff">${name}</span>`;
+    ul.appendChild(li);
+  });
+}
+
 if (typeof window !== 'undefined') {
+  // Info panel toggle
   const btnInfo = document.getElementById('btnInfo');
   const glossary = document.getElementById('glossary');
   if (btnInfo && glossary) {
-    btnInfo.addEventListener('click', () => {
-      glossary.classList.toggle('hidden');
-    });
+    btnInfo.addEventListener('click', () => glossary.classList.toggle('hidden'));
   }
 
+  // Sidebar (filters) toggle
   const btnMenu = document.getElementById('btnMenu');
   const sidebar = document.getElementById('sidebar');
   if (btnMenu && sidebar) {
     btnMenu.addEventListener('click', () => sidebar.classList.toggle('hidden'));
   }
 
+  // Populate boots legend when DOM is ready
   document.addEventListener('DOMContentLoaded', renderBootLegend);
 }
 
+// Keep named + default export for prior imports
 export default {
   normalizeDiff,
   markerColor,

--- a/app.js
+++ b/app.js
@@ -1,5 +1,4 @@
 // app.js — v12
-import { getBuildId, MAPBOX_TOKEN } from './config.js';
 
 // Normaliza etiquetas de dificultad a buckets
 export function normalizeDiff(diff) {
@@ -122,28 +121,6 @@ if (typeof window !== 'undefined') {
   }
 
   document.addEventListener('DOMContentLoaded', renderBootLegend);
-
-  // ---- Service Worker (v12) ----
-  if ('serviceWorker' in navigator) {
-    window.addEventListener('load', async () => {
-      try {
-        const reg = await navigator.serviceWorker.register(`/sw-v12.js?v=${getBuildId()}`);
-
-        if (reg.waiting) {
-          reg.waiting.postMessage({ type: 'SKIP_WAITING', buildId: getBuildId() });
-        }
-
-        let reloaded = false;
-        navigator.serviceWorker.addEventListener('controllerchange', () => {
-          if (reloaded) return;
-          reloaded = true;
-          setTimeout(() => location.reload(), 150);
-        });
-      } catch (e) {
-        console.warn('SW register failed', e);
-      }
-    });
-  }
 }
 
 export default {

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 <body>
   <!-- Topbar -->
   <header class="topbar">
-    <button id="menu-toggle" class="hamburger" aria-label="Abrir filtros">
+    <button id="btnMenu" class="hamburger" aria-label="Abrir filtros">
       <span class="bars"></span>
     </button>
     <h1>It's Gountain</h1>
@@ -71,6 +71,14 @@
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {
         navigator.serviceWorker.register("/sw-v12.js?v=12").catch(console.error);
+      });
+
+      // Guard against infinite reload loops
+      let didReload = false;
+      navigator.serviceWorker.addEventListener("controllerchange", () => {
+        if (didReload) return;
+        didReload = true;
+        setTimeout(() => location.reload(), 200);
       });
     }
   </script>

--- a/sw-v12.js
+++ b/sw-v12.js
@@ -1,13 +1,31 @@
+// sw-v12.js
 const CACHE_NAME = "gountain-cache-v12";
-const OFFLINE_URLS = [
-  "/", "/index.html", "/styles.css",
+const CORE = [
+  "/", "/index.html",
+  "/styles.css",
   "/dist/app.bundle.js",
   "/assets/GountainTime-192.png",
   "/assets/GountainTime-512.png"
 ];
 
+// Normalize versioned requests (?v=12) to canonical keys for CSS/JS
+function normalizeRequest(req) {
+  try {
+    const u = new URL(req.url);
+    const canonical = ["/styles.css", "/dist/app.bundle.js"];
+    if (canonical.includes(u.pathname) && u.search) {
+      return new Request(u.origin + u.pathname, {
+        headers: req.headers, method: req.method, mode: req.mode,
+        credentials: req.credentials, redirect: req.redirect,
+        referrer: req.referrer, referrerPolicy: req.referrerPolicy, integrity: req.integrity
+      });
+    }
+  } catch {}
+  return req;
+}
+
 self.addEventListener("install", (event) => {
-  event.waitUntil(caches.open(CACHE_NAME).then(c => c.addAll(OFFLINE_URLS)));
+  event.waitUntil(caches.open(CACHE_NAME).then(c => c.addAll(CORE)));
   self.skipWaiting();
 });
 
@@ -23,27 +41,41 @@ self.addEventListener("activate", (event) => {
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
 
-  // Always hit network for manifest and /assets/ to avoid stale icons.
+  // Don't intercept the service worker file itself
+  if (url.pathname.startsWith("/sw-")) return;
+
+  // Always hit network for manifest and /assets/ to avoid stale icons/401
   if (url.pathname === "/manifest.json" || url.pathname.startsWith("/assets/")) {
     event.respondWith(fetch(event.request));
     return;
   }
 
-  // Cache-first with network fallback for everything else
-  event.respondWith(
-    caches.match(event.request).then((cached) => {
-      if (cached) return cached;
-      return fetch(event.request)
+  // HTML/navigation -> network-first with fallback to cache
+  if (event.request.mode === "navigate" || url.pathname.endsWith(".html")) {
+    event.respondWith(
+      fetch(event.request)
         .then((res) => {
           const copy = res.clone();
-          caches.open(CACHE_NAME).then(c => c.put(event.request, copy));
+          caches.open(CACHE_NAME).then(c => c.put("/", copy));
           return res;
         })
-        .catch(() => {
-          if (event.request.mode === "navigate") {
-            return caches.match("/index.html");
-          }
-        });
+        .catch(() => caches.match("/") || caches.match("/index.html"))
+    );
+    return;
+  }
+
+  // CSS/JS/images -> stale-while-revalidate
+  const request = normalizeRequest(event.request);
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      const networkFetch = fetch(event.request).then((res) => {
+        if (res && res.status === 200 && res.type !== "opaque") {
+          const copy = res.clone();
+          caches.open(CACHE_NAME).then(c => c.put(request, copy));
+        }
+        return res;
+      }).catch(() => cached);
+      return cached || networkFetch;
     })
   );
 });


### PR DESCRIPTION
## Summary
- register the service worker once in `index.html` with a guarded controllerchange handler
- streamline app scripts by removing service worker registration
- replace `sw-v12.js` with network-first HTML and stale-while-revalidate asset caching

## Testing
- `node --test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a60277bcb4832195e7201bb982b404